### PR TITLE
ELSP-367 Move deployment template from ADO to GH

### DIFF
--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -44,8 +44,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
 extends:

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -57,8 +57,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
     # The repo will be reference the repo by a release tag (if the imageTag parameter contains 'release') otherwise it will pull down the main branch.


### PR DESCRIPTION
Repoints the `epr-webapps-code-deploy-templates` repository resource from Azure DevOps to the GitHub org (`defra/epr-webapps-code-deploy-templates`) via the `defra` service connection. Part of the ADO->GitHub templates migration.